### PR TITLE
Add command palette support

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,0 +1,6 @@
+[
+    {
+        "caption": "Filefinder",
+        "command": "filefinder"
+    }
+]


### PR DESCRIPTION
![Filefinder in command palette
](http://i.imgur.com/vmYRF1h.png)

Users can to forget keyboard shortcuts for plugin commands. And in order to run the command from the command palette, users needs only remember the name of the plugin.

Thanks.
